### PR TITLE
Add map pin

### DIFF
--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -43,3 +43,8 @@ required-features = ["probes"]
 name = "biolatpcts"
 path = "src/biolatpcts/main.rs"
 required-features = ["probes"]
+
+[[bin]]
+name = "tc-test"
+path = "src/tc_test/main.rs"
+required-features = ["probes"]

--- a/examples/example-probes/src/tc_test/main.rs
+++ b/examples/example-probes/src/tc_test/main.rs
@@ -1,0 +1,120 @@
+// This program can be executed by
+// # cargo run --example tcp-lifetime [interface]
+#![no_std]
+#![no_main]
+use core::marker::PhantomData;
+use core::mem;
+use redbpf_macros::map;
+use redbpf_probes::tc::prelude::*;
+use redbpf_probes::tc::{TcAction, TcActionResult};
+
+program!(0xFFFFFFFE, "GPL");
+
+const PIN_GLOBAL_NS: u32 = 2;
+
+#[repr(C)]
+struct bpf_elf_map {
+    type_: u32,
+    size_key: u32,
+    size_value: u32,
+    max_elem: u32,
+    flags: u32,
+    id: u32,
+    pinning: u32,
+}
+
+pub struct TcHashMap<K, V> {
+    def: bpf_elf_map,
+    _k: PhantomData<K>,
+    _v: PhantomData<V>,
+}
+
+impl<K, V> TcHashMap<K, V> {
+    /// Creates a map with the specified maximum number of elements.
+    pub const fn with_max_entries(max_entries: u32) -> Self {
+        Self {
+            def: bpf_elf_map {
+                type_: 1, // BPF_MAP_TYPE_HASH
+                size_key: mem::size_of::<K>() as u32,
+                size_value: mem::size_of::<V>() as u32,
+                max_elem: max_entries,
+                flags: 0,
+                id: 0,
+                pinning: PIN_GLOBAL_NS,
+            },
+            _k: PhantomData,
+            _v: PhantomData,
+        }
+    }
+    /// Returns a reference to the value corresponding to the key.
+    #[inline]
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        unsafe {
+            let value = bpf_map_lookup_elem(
+                &mut self.def as *mut _ as *mut _,
+                key as *const _ as *const _,
+            );
+            if value.is_null() {
+                None
+            } else {
+                Some(&*(value as *const V))
+            }
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        unsafe {
+            let value = bpf_map_lookup_elem(
+                &mut self.def as *mut _ as *mut _,
+                key as *const _ as *const _,
+            );
+            if value.is_null() {
+                None
+            } else {
+                Some(&mut *(value as *mut V))
+            }
+        }
+    }
+
+    /// Set the `value` in the map for `key`
+    #[inline]
+    pub fn set(&mut self, key: &K, value: &V) {
+        unsafe {
+            bpf_map_update_elem(
+                &mut self.def as *mut _ as *mut _,
+                key as *const _ as *const _,
+                value as *const _ as *const _,
+                BPF_ANY.into(),
+            );
+        }
+    }
+
+    /// Delete the entry indexed by `key`
+    #[inline]
+    pub fn delete(&mut self, key: &K) {
+        unsafe {
+            bpf_map_delete_elem(
+                &mut self.def as *mut _ as *mut _,
+                key as *const _ as *const _,
+            );
+        }
+    }
+}
+
+#[map(link_section = "maps")]
+static mut blocked_packets: TcHashMap<u64, u64> = TcHashMap::<u64, u64>::with_max_entries(1024);
+
+#[tc_action]
+fn test_tc(skb: SkBuff) -> TcActionResult {
+    unsafe {
+        let key = 0;
+        if let Some(mut cnt) = blocked_packets.get_mut(&key) {
+            *cnt += 1;
+        } else {
+            let val = 0;
+            blocked_packets.set(&key, &val);
+        }
+    }
+    Ok(TcAction::Ok)
+}

--- a/examples/example-userspace/build.rs
+++ b/examples/example-userspace/build.rs
@@ -17,4 +17,5 @@ fn main() {
         .for_each(|file| {
             println!("cargo:rerun-if-changed={}", file);
         });
+    println!("cargo:rerun-if-changed=../example-probes/Cargo.toml");
 }

--- a/examples/example-userspace/examples/tc-test.rs
+++ b/examples/example-userspace/examples/tc-test.rs
@@ -1,0 +1,35 @@
+use redbpf::{HashMap, Map};
+use std::process;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::{error, Level};
+use tracing_subscriber::FmtSubscriber;
+
+const MAP_PIN_PATH: &str = "/sys/fs/bpf/tc/globals/blocked_packets";
+
+async fn monitor() {
+    let map = Map::from_pin_path(MAP_PIN_PATH).expect("error on creating map from pin path");
+    let persist_map = HashMap::<u64, u64>::new(&map).expect("error on creating Array");
+
+    loop {
+        if let Some(cnt) = persist_map.get(0) {
+            println!("blocked packet number: {}", cnt);
+        }
+
+        sleep(Duration::from_secs(1)).await
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    if unsafe { libc::getuid() != 0 } {
+        error!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+    monitor().await;
+}

--- a/redbpf-probes/build.rs
+++ b/redbpf-probes/build.rs
@@ -47,7 +47,8 @@ fn rerun_if_changed_dir(dir: &str) {
 }
 
 fn main() {
-    rerun_if_changed_dir("include");
+    rerun_if_changed_dir("../include");
+    rerun_if_changed_dir("../bpf-sys/libbpf/src");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let types = ["pt_regs", "s32", "bpf_.*"];


### PR DESCRIPTION
@dunateo

I am adding new feature for pinning bpf maps.

This PR shows you how to define `TcHashMap` which is compatible with tc.
I defined `TcHashMap` as a replacement of `HashMap` of redbpf.
Because `HashMap` of redbpf utilizes `bpf_map_def` and tc uses `bpf_elf_map` structure, you can not use HashMap of redbpf for tc. But I do not know why normal HashMap is working fine with tc.


`Map::from_pin_path` can be used to create `Map` instance from pinned maps.


The usage scenario is 
1. run `cargo build --example tc-test`, then tc-test.elf is generated.
2. run `llvm-objcopy-11 --remove-section .text target/debug/build/example-userspace-562684cf2c45fccb/out/target/bpf/programs/tc-test/tc-test.elf tc-test.elf` to remove .text section.
3. run `sudo tc filter add dev lo ingress bpf da obj tc-test.elf sec tc_action/test_tc` command, then this command creates /sys/fs/bpf/tc/global/blocked_packets
4. run `sudo cargo run --example tc-test` as root user, then the program monitors the pinned map periodically
5. run `curl localhost`, then you can see that the counter reported by tc-test changes.