### PR TITLE
Add Module::parse_with_map and sharemap examples

### DIFF
--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -43,3 +43,13 @@ required-features = ["probes"]
 name = "biolatpcts"
 path = "src/biolatpcts/main.rs"
 required-features = ["probes"]
+
+[[bin]]
+name = "sharemap1"
+path = "src/sharemap1/main.rs"
+required-features = ["probes"]
+
+[[bin]]
+name = "sharemap2"
+path = "src/sharemap2/main.rs"
+required-features = ["probes"]

--- a/examples/example-probes/src/sharemap1/main.rs
+++ b/examples/example-probes/src/sharemap1/main.rs
@@ -1,0 +1,17 @@
+#![no_std]
+#![no_main]
+
+use redbpf_probes::kprobe::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[map("sharedmap")]
+static mut SHARED_COUNT: Array<i64> = Array::with_max_entries(1);
+
+#[kprobe]
+fn vfs_read(_: Registers) {
+    unsafe {
+        let mut cnt = SHARED_COUNT.get_mut(0).unwrap();
+        *cnt += 1;
+    }
+}

--- a/examples/example-probes/src/sharemap2/main.rs
+++ b/examples/example-probes/src/sharemap2/main.rs
@@ -1,0 +1,17 @@
+#![no_std]
+#![no_main]
+
+use redbpf_probes::kprobe::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[map("sharedmap")]
+static mut SHARED_COUNT: Array<i64> = Array::with_max_entries(1);
+
+#[kprobe]
+fn vfs_write(_: Registers) {
+    unsafe {
+        let mut cnt = SHARED_COUNT.get_mut(0).unwrap();
+        *cnt = 0;
+    }
+}

--- a/examples/example-userspace/examples/sharemap1.rs
+++ b/examples/example-userspace/examples/sharemap1.rs
@@ -1,0 +1,58 @@
+use redbpf::load::Loader;
+use redbpf::Array;
+use std::process;
+use std::time::Duration;
+use tokio::signal::ctrl_c;
+use tokio::time::sleep;
+use tracing::{debug, error, Level};
+use tracing_subscriber::FmtSubscriber;
+
+const PIN_FILE: &str = "/sys/fs/bpf/sharedmap";
+const MAP_NAME: &str = "sharedmap";
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+    if unsafe { libc::getuid() != 0 } {
+        error!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+
+    let mut loaded = Loader::load(probe_code()).unwrap();
+    loaded
+        .map_mut(MAP_NAME)
+        .expect("map not found")
+        .pin(PIN_FILE)
+        .expect("error on pinning");
+    for kp in loaded.kprobes_mut() {
+        debug!("attach_kprobe on {}", kp.name());
+        kp.attach_kprobe(&kp.name(), 0)
+            .expect("error on attach_kprobe");
+    }
+    let sarray = Array::<u64>::new(loaded.map_mut(MAP_NAME).unwrap()).expect("error on Array::new");
+    loop {
+        println!("shared counter: {}", sarray.get(0).unwrap());
+        tokio::select! {
+            _ = sleep(Duration::from_secs(1)) => {}
+            _ = ctrl_c() => {
+                break;
+            }
+        }
+    }
+
+    loaded
+        .map_mut(MAP_NAME)
+        .unwrap()
+        .unpin()
+        .expect("error on unpin");
+}
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/target/bpf/programs/sharemap1/sharemap1.elf"
+    ))
+}

--- a/examples/example-userspace/examples/sharemap2.rs
+++ b/examples/example-userspace/examples/sharemap2.rs
@@ -1,0 +1,56 @@
+use redbpf::{Array, Map, Module};
+use std::process;
+use std::time::Duration;
+use tokio::signal::ctrl_c;
+use tokio::time::sleep;
+use tracing::{debug, error, Level};
+use tracing_subscriber::FmtSubscriber;
+
+const PIN_FILE: &str = "/sys/fs/bpf/sharedmap";
+const MAP_NAME: &str = "sharedmap";
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+    if unsafe { libc::getuid() != 0 } {
+        error!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+
+    let mut module = Module::parse_with_maps(
+        probe_code(),
+        vec![Map::from_pin_file(PIN_FILE).expect("error on Map::from_pin_file")],
+    )
+    .unwrap();
+    for prog in module.programs.iter_mut() {
+        debug!("load program: {}", prog.name());
+        prog.load(module.version, module.license.clone())
+            .expect("error on load program");
+    }
+    for kp in module.kprobes_mut() {
+        debug!("attach kprobe: {}", kp.name());
+        kp.attach_kprobe(&kp.name(), 0)
+            .expect("error on attach_kprobe");
+    }
+    let sarray = Array::<u64>::new(module.map(MAP_NAME).expect("map not found"))
+        .expect("error on Array::new");
+    loop {
+        println!("shared counter: {}", sarray.get(0).unwrap());
+        tokio::select! {
+            _ = sleep(Duration::from_secs(1)) => {}
+            _ = ctrl_c() => {
+                break;
+            }
+        }
+    }
+}
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/target/bpf/programs/sharemap2/sharemap2.elf"
+    ))
+}


### PR DESCRIPTION
Hello @Dunateo

I am working on this feature for sharing maps between bpf programs in kernel land.

I added `Module::parse_with_map` of which most part is copied from `Module::parse`.
You can find little difference between `Module::parse_with_map` and `Module::parse`.
And `sharemap1` and `sharemap2` examples are also added as a PoC.
They show one BPF map is shared between two bpf programs.

As you can see, parse_with_map is not suitable to be added to main branch, it is just written for PoC.
Some refactoring should be done. And I will send PR to foniod/redbpf.

I hope this code helps you and I wish you to succeed in your project.
Thanks,